### PR TITLE
[FIX] fq: pass full path to lock file to inotify_add_watch

### DIFF
--- a/fq.c
+++ b/fq.c
@@ -157,6 +157,10 @@ main(int argc, char *argv[])
 		char fullpath[PATH_MAX];
 		snprintf(fullpath, PATH_MAX, "%s/%s", path, argv[i]);
 		wd = inotify_add_watch(ifd, fullpath, IN_MODIFY | IN_CLOSE_WRITE);
+		if (wd == -1) {
+			perror("inotify_add_watch");
+			exit(1);
+		}
 #endif
 
 		while (1) {

--- a/fq.c
+++ b/fq.c
@@ -154,7 +154,9 @@ main(int argc, char *argv[])
 		didsth = 1;
 
 #ifdef USE_INOTIFY
-		wd = inotify_add_watch(ifd, argv[i], IN_MODIFY | IN_CLOSE_WRITE);
+		char fullpath[PATH_MAX];
+		snprintf(fullpath, PATH_MAX, "%s/%s", path, argv[i]);
+		wd = inotify_add_watch(ifd, fullpath, IN_MODIFY | IN_CLOSE_WRITE);
 #endif
 
 		while (1) {


### PR DESCRIPTION
When NQDIR is set, we cannot expect the lock files to be found under the working directory.