### PR TITLE
Add an INSTALL variable to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man
 
+INSTALL=install
+
 all: $(ALL)
 
 clean: FRC
@@ -17,7 +19,7 @@ check: FRC all
 
 install: FRC all
 	mkdir -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1
-	install -m0755 $(ALL) $(DESTDIR)$(BINDIR)
-	install -m0644 $(ALL:=.1) $(DESTDIR)$(MANDIR)/man1
+	$(INSTALL) -m0755 $(ALL) $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m0644 $(ALL:=.1) $(DESTDIR)$(MANDIR)/man1
 
 FRC:


### PR DESCRIPTION
This is useful to distribution packagers who may wish to set

```sh
INSTALL='install -p'
```

in order to preserve timestamps from the source tarball.