### PR TITLE
Gitignore the macOS-specific `.dSYM/` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 nq
 nqtail
 ,*.*
+
+# The following directories are specific to macOS:
+nq.dSYM/
+nqtail.dSYM/


### PR DESCRIPTION
If I clone this repo, and do `make all` on a macOS machine, I end up with several directories that don't seem to currently be `gitignore`d:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	nq.dSYM/
	nqtail.dSYM/
```

This PR adds those two directories to the `.gitignore` file.